### PR TITLE
Rename to "Core Ontology for Biology and Biomedicine"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Core Open Biological Ontology (COB)
+# Core Ontology for Biology and Biomedicine (COB)
 
 This project is an attempt to bring together key terms from a wide range of [Open Biological and Biomedical Ontology (OBO)](http://obofoundry.org) projects into a single, small ontology. The goal is to improve interoperabilty and reuse across the OBO community through better coordination of key terms. Our plan is to keep this ontology small, but ensure that one or more COB terms can be used as the root of any given OBO library ontology.
 

--- a/cob-edit.owl
+++ b/cob-edit.owl
@@ -12,7 +12,7 @@
      xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob/cob-edit.owl">
         <dc:description xml:lang="en">COB brings together key terms from a wide range of OBO projects to improve interoperability.</dc:description>
-        <dc:title xml:lang="en">Core Open Biological Ontology</dc:title>
+        <dc:title xml:lang="en">Core Ontology for Biology and Biomedicine</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
     </owl:Ontology>
     

--- a/cob.owl
+++ b/cob.owl
@@ -11,9 +11,9 @@
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
      xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/2020-02-12/cob.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/2020-04-15/cob.owl"/>
         <dc:description xml:lang="en">COB brings together key terms from a wide range of OBO projects to improve interoperability.</dc:description>
-        <dc:title xml:lang="en">Core Open Biological Ontology</dc:title>
+        <dc:title xml:lang="en">Core Ontology for Biology and Biomedicine</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
     </owl:Ontology>
     


### PR DESCRIPTION
After the recent poll, we have decided on the name "Core Ontology for Biology and Biomedicine" for COB. This changes the name in corresponding files.