### PR TITLE
make and make test failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ cob.tsv: cob.owl
 cob-to-external.ttl: cob-to-external.tsv
 	./util/tsv2rdf.pl $< > $@.tmp && mv $@.tmp $@
 cob-to-external.owl: cob-to-external.ttl
-	$(ROBOT) convert -i $< -o $@
+	$(ROBOT) -vvv convert -i $< -o $@
 
 # -- TESTING --
 


### PR DESCRIPTION
`make` and `make test` are failing. See attached error logs.   
I believe the problem is with `robot convert`.

[make-error.txt](https://github.com/OBOFoundry/COB/files/5081820/make-error.txt)
[make-test-error.txt](https://github.com/OBOFoundry/COB/files/5081821/make-test-error.txt)
