### PR TITLE
Add annotations module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ build/report.tsv: cob-edit.owl | build/robot.jar
 
 # build main release product
 cob.owl: cob-edit.owl | build/robot.jar
-	$(ROBOT) reason --input $< --reasoner hermit \
+	$(ROBOT) remove --input $< \
+	--select imports \
+	reason --reasoner hermit \
 	annotate \
 	--ontology-iri "http://purl.obolibrary.org/obo/$@" \
 	--annotation owl:versionInfo $(DATE) \
@@ -57,8 +59,18 @@ cob.tsv: cob.owl
 # this is a really hacky way to do this, replace with robot report?
 cob-to-external.ttl: cob-to-external.tsv
 	./util/tsv2rdf.pl $< > $@.tmp && mv $@.tmp $@
+
 cob-to-external.owl: cob-to-external.ttl
 	$(ROBOT) convert -i $< -o $@
+
+build/cob-annotations.ttl: cob-to-external.owl sparql/external-links.rq | build/robot.jar
+	$(ROBOT) query --input $< --query $(word 2,$^) $@
+
+cob-annotations.owl: build/cob-annotations.ttl | build/robot.jar
+	$(ROBOT) annotate --input $< \
+	--ontology-iri "http://purl.obolibrary.org/obo/cob/$@" \
+	--annotation owl:versionInfo $(DATE) \
+	--output $@
 
 # -- TESTING --
 

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="http://purl.obolibrary.org/obo/cob/cob-annotations.owl" uri="cob-annotations.owl"/>
     <uri name="http://purl.obolibrary.org/obo/cob/cob-edit.owl" uri="cob-edit.owl"/>
 </catalog>

--- a/cob-annotations.owl
+++ b/cob-annotations.owl
@@ -1,0 +1,208 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/cob/cob-annotations.owl#"
+     xml:base="http://purl.obolibrary.org/obo/cob/cob-annotations.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob/cob-annotations.owl">
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020-08-28</owl:versionInfo>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_based_on -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/COB_based_on">
+        <rdfs:label>based on</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000001">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000019</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000003">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/PATO_0000125</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000004">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/PATO_0002193</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000006">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000040</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000007">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_36342</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000008">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_24636</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000009">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_30222</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000010">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_10545</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000011">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_33250</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000012">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_33252</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000013">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_23367</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000015">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_16541</obo:COB_based_on>
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/PR_000000001</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000017">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CL_0000000</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000018">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CL_0000003</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000019">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CL_0001034</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000021">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CARO_0001008</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000022">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CARO_0001010</obo:COB_based_on>
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0100026</obo:COB_based_on>
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/NCBITaxon_1</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000025">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000245</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000026">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000047</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000031">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000041</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000033">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000017</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000034">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000015</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000035">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000011</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000037">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/GO_0008150</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000038">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/GO_0003674</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000042">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CHEBI_24867</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000055">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/PCO_0000000</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000057">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000029</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000058">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0001909</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000061">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000030</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000062">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OGMS_0000073</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000063">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OGMS_0000014</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000064">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OGMS_0000063</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000065">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/ENVO_02500000</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000067">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/ENVO_01001110</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000068">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/ENVO_01000813</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000069">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000033</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000075">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/GO_0032991</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000076">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000005</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000079">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000104</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000101">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000310</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000102">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000027</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000103">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/GO_0005634</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000107">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000070</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000108">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0200000</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000109">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/IAO_0000066</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000110">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000094</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000111">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000016</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000112">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000034</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000113">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/OBI_0000260</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000114">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/BFO_0000023</obo:COB_based_on>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/NCBITaxon_131567</obo:COB_based_on>
+        <obo:COB_based_on>http://purl.obolibrary.org/obo/CARO_0010004</obo:COB_based_on>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+

--- a/cob-edit.owl
+++ b/cob-edit.owl
@@ -11,6 +11,7 @@
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
      xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob/cob-edit.owl">
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/cob/cob-annotations.owl"/>
         <dc:description xml:lang="en">COB brings together key terms from a wide range of OBO projects to improve interoperability.</dc:description>
         <dc:title xml:lang="en">Core Ontology for Biology and Biomedicine</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>

--- a/cob.owl
+++ b/cob.owl
@@ -14,7 +14,7 @@
         <dc:description xml:lang="en">COB brings together key terms from a wide range of OBO projects to improve interoperability.</dc:description>
         <dc:title xml:lang="en">Core Ontology for Biology and Biomedicine</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020-08-28</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020-05-14</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -38,30 +38,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/description -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/title -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/license -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
-    
-
-
     <!-- http://www.w3.org/2004/02/skos/core#exactMatch -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#exactMatch"/>
@@ -82,8 +58,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000039 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000039">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000035"/>
         <rdfs:label xml:lang="en">has specified input</rdfs:label>
     </owl:ObjectProperty>
     
@@ -92,8 +66,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000040 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000040">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000035"/>
         <rdfs:label xml:lang="en">has specified output</rdfs:label>
     </owl:ObjectProperty>
     
@@ -102,8 +74,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000041 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000041">
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/COB_0000001"/>
-        <rdfs:comment>Note: this will end up being a subproperty of has-characteristic when we add it, TBD depends on discussion of whether has-characteristic is functional</rdfs:comment>
         <rdfs:label xml:lang="en">has quality</rdfs:label>
     </owl:ObjectProperty>
     
@@ -121,7 +91,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000070 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000070">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
         <rdfs:label>has participant</rdfs:label>
     </owl:ObjectProperty>
     
@@ -130,7 +99,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000071 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000071">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
         <rdfs:label>occurs in</rdfs:label>
     </owl:ObjectProperty>
     
@@ -139,7 +107,6 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000072 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000072">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label>part of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -151,46 +118,6 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
         <rdfs:label>enabled by</rdfs:label>
     </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/COB_0000512 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000512">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <rdfs:label>has characteristic</rdfs:label>
-        <rdfs:seeAlso>https://github.com/oborel/obo-relations/pull/284</rdfs:seeAlso>
-    </owl:ObjectProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
-        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:comment>Anything can have a characteristic</rdfs:comment>
-    </owl:Axiom>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/COB_0000511 -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000511">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <rdfs:comment>The range of this property should be a user-defined unit datatype, e.g 182^:cm</rdfs:comment>
-        <rdfs:label>has quantity</rdfs:label>
-        <rdfs:seeAlso>https://github.com/OBOFoundry/COB/issues/35</rdfs:seeAlso>
-    </owl:DatatypeProperty>
     
 
 
@@ -208,7 +135,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000001">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:label xml:lang="en">quality</rdfs:label>
     </owl:Class>
     
@@ -235,10 +162,8 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000005">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">no longer needed</obo:IAO_0000116>
-        <rdfs:label xml:lang="en">obsolete_elementary charge</rdfs:label>
-        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000004"/>
+        <rdfs:label xml:lang="en">elementary charge</rdfs:label>
     </owl:Class>
     
 
@@ -474,7 +399,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000033 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000033">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <rdfs:label xml:lang="en">realizable</rdfs:label>
     </owl:Class>
     
@@ -484,12 +409,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000034">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/COB_0000072"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">process</rdfs:label>
     </owl:Class>
     
@@ -911,17 +830,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
         <rdfs:label xml:lang="en">cellular organism</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/COB_0000502 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:label xml:lang="en">characteristic</rdfs:label>
-        <rdfs:seeAlso>https://github.com/OBOFoundry/COB/issues/65</rdfs:seeAlso>
-        <rdfs:seeAlso>https://github.com/oborel/obo-relations/pull/284</rdfs:seeAlso>
     </owl:Class>
 </rdf:RDF>
 

--- a/cob.owl
+++ b/cob.owl
@@ -14,7 +14,7 @@
         <dc:description xml:lang="en">COB brings together key terms from a wide range of OBO projects to improve interoperability.</dc:description>
         <dc:title xml:lang="en">Core Ontology for Biology and Biomedicine</dc:title>
         <terms:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020-05-14</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020-08-28</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -38,6 +38,30 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/description -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/title -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/license -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
+    
+
+
     <!-- http://www.w3.org/2004/02/skos/core#exactMatch -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#exactMatch"/>
@@ -58,6 +82,8 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000039 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000039">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000035"/>
         <rdfs:label xml:lang="en">has specified input</rdfs:label>
     </owl:ObjectProperty>
     
@@ -66,6 +92,8 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000040 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000040">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000035"/>
         <rdfs:label xml:lang="en">has specified output</rdfs:label>
     </owl:ObjectProperty>
     
@@ -74,6 +102,8 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000041 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000041">
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/COB_0000001"/>
+        <rdfs:comment>Note: this will end up being a subproperty of has-characteristic when we add it, TBD depends on discussion of whether has-characteristic is functional</rdfs:comment>
         <rdfs:label xml:lang="en">has quality</rdfs:label>
     </owl:ObjectProperty>
     
@@ -91,6 +121,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000070 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000070">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
         <rdfs:label>has participant</rdfs:label>
     </owl:ObjectProperty>
     
@@ -99,6 +130,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000071 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000071">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
         <rdfs:label>occurs in</rdfs:label>
     </owl:ObjectProperty>
     
@@ -107,6 +139,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000072 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000072">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label>part of</rdfs:label>
     </owl:ObjectProperty>
     
@@ -118,6 +151,46 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000070"/>
         <rdfs:label>enabled by</rdfs:label>
     </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000512 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000512">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <rdfs:label>has characteristic</rdfs:label>
+        <rdfs:seeAlso>https://github.com/oborel/obo-relations/pull/284</rdfs:seeAlso>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000512"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#domain"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:comment>Anything can have a characteristic</rdfs:comment>
+    </owl:Axiom>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000511 -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000511">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <rdfs:comment>The range of this property should be a user-defined unit datatype, e.g 182^:cm</rdfs:comment>
+        <rdfs:label>has quantity</rdfs:label>
+        <rdfs:seeAlso>https://github.com/OBOFoundry/COB/issues/35</rdfs:seeAlso>
+    </owl:DatatypeProperty>
     
 
 
@@ -135,7 +208,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000001">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
         <rdfs:label xml:lang="en">quality</rdfs:label>
     </owl:Class>
     
@@ -162,8 +235,10 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000005">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000004"/>
-        <rdfs:label xml:lang="en">elementary charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">no longer needed</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">obsolete_elementary charge</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -399,7 +474,7 @@
     <!-- http://purl.obolibrary.org/obo/COB_0000033 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000033">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
         <rdfs:label xml:lang="en">realizable</rdfs:label>
     </owl:Class>
     
@@ -409,6 +484,12 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000034">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/COB_0000072"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/COB_0000034"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">process</rdfs:label>
     </owl:Class>
     
@@ -830,6 +911,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
         <rdfs:label xml:lang="en">cellular organism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000502 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:label xml:lang="en">characteristic</rdfs:label>
+        <rdfs:seeAlso>https://github.com/OBOFoundry/COB/issues/65</rdfs:seeAlso>
+        <rdfs:seeAlso>https://github.com/oborel/obo-relations/pull/284</rdfs:seeAlso>
     </owl:Class>
 </rdf:RDF>
 

--- a/sparql/external-links.rq
+++ b/sparql/external-links.rq
@@ -1,0 +1,20 @@
+PREFIX COB: <http://purl.obolibrary.org/obo/COB_>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+   COB:based_on a owl:AnnotationProperty ;
+                rdfs:label "based on" .
+   ?x COB:based_on ?link .
+}
+WHERE {
+ {
+   ?x owl:equivalentClass ?ext .
+   FILTER(STRSTARTS(STR(?x), "http://purl.obolibrary.org/obo/COB_"))
+   BIND(STR(?ext) AS ?link)
+ } UNION {
+   ?ext owl:equivalentClass ?x .
+   FILTER(STRSTARTS(STR(?x), "http://purl.obolibrary.org/obo/COB_"))
+   BIND(STR(?ext) AS ?link)
+ }
+}


### PR DESCRIPTION
Create a `cob-annotations.owl` file based on `cob-to-external.owl`. This module contains links to the external terms as annotations (`COB:based_on`, though I'm happy to change this to whatever we'd like).

This import module is removed when `cob.owl` is generated.

Unrelated, but should we consider converting `cob-to-external.tsv` to a ROBOT template?