### PR TITLE
Add SO terms to cob-to-external, fix subclass rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 catalog-v001.xml
 build/robot.jar
 build/cob-annotations.ttl
+build/cob-to-external.ttl

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ cob.tsv: cob.owl | build/robot.jar
 #  OWL is generated from this
 #
 # this is a really hacky way to do this, replace with robot report?
-cob-to-external.ttl: cob-to-external.tsv
+build/cob-to-external.ttl: cob-to-external.tsv
 	./util/tsv2rdf.pl $< > $@.tmp && mv $@.tmp $@
 
-cob-to-external.owl: cob-to-external.ttl | build/robot.jar
+cob-to-external.owl: build/cob-to-external.ttl | build/robot.jar
 	$(ROBOT) convert -i $< -o $@
 
 build/cob-annotations.ttl: cob-to-external.owl sparql/external-links.rq | build/robot.jar

--- a/cob-to-external.owl
+++ b/cob-to-external.owl
@@ -693,7 +693,9 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000502 -->
 
-    <Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502"/>
+    <Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
+        <equivalentClass rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+    </Class>
     
 
 
@@ -712,6 +714,14 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_02500000 -->
 
     <Class rdf:about="http://purl.obolibrary.org/obo/ENVO_02500000"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
+    </Class>
     
 
 
@@ -871,6 +881,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0000001 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000001"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0000125 -->
 
     <Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000125"/>
@@ -889,9 +905,113 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PO_0000003 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/PO_0000003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0009002 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/PO_0009002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0025117 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/PO_0025117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0025606 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/PO_0025606">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PR_000000001 -->
 
     <Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000110 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/SO_0000110">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000400 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/SO_0000400">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001060 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/SO_0001060">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001260 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/SO_0001260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000466 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000468 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/XAO_0003012 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/XAO_0003012">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ZFA_0009000 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/ZFA_0009000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </Class>
 </rdf:RDF>
 
 

--- a/cob-to-external.tsv
+++ b/cob-to-external.tsv
@@ -4,6 +4,9 @@ COB:0000003	mass	owl:equivalentClass	PATO:0000125	mass	.
 COB:0000004	charge	owl:equivalentClass	PATO:0002193	electric	.
 COB:0000005	elementary charge				Making ticket in PATO tracker
 COB:0000006	material entity	owl:equivalentClass	BFO:0000040	material entity	.
+COB:0000006	material entity	SUPERCLASS_OF	SO:0000110	sequence_feature	.
+COB:0000006	material entity	SUPERCLASS_OF	SO:0001060	sequence_variant	.
+COB:0000006	material entity	SUPERCLASS_OF	SO:0001260	sequence_collection	.
 COB:0000007	subatomic particle	owl:equivalentClass	CHEBI:36342	subatomic particle	.
 COB:0000008	proton	owl:equivalentClass	CHEBI:24636	proton	.
 COB:0000009	neutron	owl:equivalentClass	CHEBI:30222	neutron	.
@@ -83,5 +86,6 @@ COB:0000072	part of	owl:equivalentProperty	BFO:0000050	part of	.
 COB:0000074	enabled by	owl:equivalentProperty	RO:0002333	enabled by	.
 COB:0000502	characteristic	owl:equivalentClass	PATO:0000001	quality	https://github.com/OBOFoundry/COB/issues/124
 COB:0000502	characteristic	owl:equivalentClass	BFO:0000020	specifically dependent continuant	may be revised to be narrower
+COB:0000502	characteristic	SUPERCLASS_OF	SO:0000400	sequence_attribute	.
 COB:0000511	has quantity				.
 COB:0000512	has characteristic	owl:equivalentProperty	RO:0000053	bearer of	.

--- a/util/tsv2rdf.pl
+++ b/util/tsv2rdf.pl
@@ -39,7 +39,7 @@ while(<>) {
     print ":$s a $type .\n";
     if ($p eq 'SUPERCLASS_OF') {
         ($s,$o) = ($o,$s);
-        $p = 'owl:subClassOf';
+        $p = 'rdfs:subClassOf';
     }
     print ":$s $p :$o .\n";
 }


### PR DESCRIPTION
See #52 - we may want more discussion before considering this resolved?

Also, the `tsv2rdf.pl` script was using the property `owl:subClassOf` instead of `rdfs:subClassOf` so the subclasses were not showing up in `cob-to-external.owl`. I fixed this and regenerated. I hope that's OK!