### PR TITLE
Add superclass mapping from COB characteristic to ChEBI role

### DIFF
--- a/src/ontology/cob.Makefile
+++ b/src/ontology/cob.Makefile
@@ -81,7 +81,7 @@ cob.tsv: cob.owl
 # this is a really hacky way to do this, replace with robot report?
 .PHONY: sssom
 sssom:
-	pip install sssom
+	pip install sssom pandasql
 	pip install --upgrade --no-deps --force-reinstall sssom==0.3.2
 
 $(TMPDIR)/cob-to-external.sssom.owl: $(COMPONENTSDIR)/cob-to-external.tsv | sssom

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -103,7 +103,7 @@ COB:0000111	disposition	owl:equivalentClass	BFO:0000016	disposition	.
 COB:0000112	function	owl:equivalentClass	BFO:0000034	function	.
 COB:0000113	plan	owl:equivalentClass	OBI:0000260	plan	.
 COB:0000114	role	owl:equivalentClass	BFO:0000023	role	.
-COB:0000114	role	owl:equivalentClass	CHEBI:50906 	role	.
+COB:0000114	role	owl:equivalentClass	CHEBI:50906	role	.
 COB:0000116	cellular membrane	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000118	cellular organism	owl:equivalentClass	NCBITaxon:131567	cellular organisms	.
 COB:0000118	cellular organism	owl:equivalentClass	CARO:0010004	cellular organism	.

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -92,7 +92,7 @@ COB:0000076	objective specification	owl:equivalentClass	IAO:0000005	objective sp
 COB:0000079	plan specification	owl:equivalentClass	IAO:0000104	plan specification	.
 COB:0000080	complex of molecular entities	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000088	drug product	owl:equivalentClass	DRON:0000005	drug product	we currently use a different text definition but we believe they do not contradict
-COB:0000088	drug product	owl:equivalentClass	CHEBI:23888	drug product	we currently use a different text definition but we believe they do not contradict
+COB:0000088	drug product	owl:equivalentClass	CHEBI:23888	drug	.
 COB:0000101	document	owl:equivalentClass	IAO:0000310	document	.
 COB:0000102	data item	owl:equivalentClass	IAO:0000027	data item	.
 COB:0000103	cell nucleus	owl:equivalentClass	GO:0005634	nucleus	.

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -104,7 +104,7 @@ COB:0000111	disposition	owl:equivalentClass	BFO:0000016	disposition	.
 COB:0000112	function	owl:equivalentClass	BFO:0000034	function	.
 COB:0000113	plan	owl:equivalentClass	OBI:0000260	plan	.
 COB:0000114	role	owl:equivalentClass	BFO:0000023	role	.
-COB:0000114	role	owl:equivalentClass	CHEBI:50906	role	.
+COB:0000502	characteristic	sssom:superClassOf	CHEBI:50906	role	The ChEBI notion of a role doesn't strictly follow the BFO sense of either being a role or disposition, meaning that it's hard, if not impossible, to impose BFO order to this branch of ChEBI. See issue #173
 COB:0000116	cellular membrane	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000118	cellular organism	owl:equivalentClass	NCBITaxon:131567	cellular organisms	.
 COB:0000118	cellular organism	owl:equivalentClass	CARO:0010004	cellular organism	.

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -103,6 +103,7 @@ COB:0000111	disposition	owl:equivalentClass	BFO:0000016	disposition	.
 COB:0000112	function	owl:equivalentClass	BFO:0000034	function	.
 COB:0000113	plan	owl:equivalentClass	OBI:0000260	plan	.
 COB:0000114	role	owl:equivalentClass	BFO:0000023	role	.
+COB:0000114	role	owl:equivalentClass	CHEBI:50906 	role	.
 COB:0000116	cellular membrane	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000118	cellular organism	owl:equivalentClass	NCBITaxon:131567	cellular organisms	.
 COB:0000118	cellular organism	owl:equivalentClass	CARO:0010004	cellular organism	.

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -92,7 +92,7 @@ COB:0000076	objective specification	owl:equivalentClass	IAO:0000005	objective sp
 COB:0000079	plan specification	owl:equivalentClass	IAO:0000104	plan specification	.
 COB:0000080	complex of molecular entities	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000088	drug product	owl:equivalentClass	DRON:0000005	drug product	we currently use a different text definition but we believe they do not contradict
-COB:0000088	drug product	owl:equivalentClass	CHEBI:23888	drug	.
+COB:0000088	drug product	rdfs:seeAlso	CHEBI:23888	drug	These can't be equivalent because COB drug product is a material entity, and ChEBI's drug is a role. See issue #140 for more information.
 COB:0000101	document	owl:equivalentClass	IAO:0000310	document	.
 COB:0000102	data item	owl:equivalentClass	IAO:0000027	data item	.
 COB:0000103	cell nucleus	owl:equivalentClass	GO:0005634	nucleus	.

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -92,6 +92,7 @@ COB:0000076	objective specification	owl:equivalentClass	IAO:0000005	objective sp
 COB:0000079	plan specification	owl:equivalentClass	IAO:0000104	plan specification	.
 COB:0000080	complex of molecular entities	rdfs:subClassOf	owl:Thing	owl:Thing	
 COB:0000088	drug product	owl:equivalentClass	DRON:0000005	drug product	we currently use a different text definition but we believe they do not contradict
+COB:0000088	drug product	owl:equivalentClass	CHEBI:23888	drug product	we currently use a different text definition but we believe they do not contradict
 COB:0000101	document	owl:equivalentClass	IAO:0000310	document	.
 COB:0000102	data item	owl:equivalentClass	IAO:0000027	data item	.
 COB:0000103	cell nucleus	owl:equivalentClass	GO:0005634	nucleus	.


### PR DESCRIPTION
Closes #169

This PR adds an explicit equivalence mapping between COB and ChEBI:
- COB:0000502 (characteristic) `sssom:superClassOf` CHEBI:50906 (role)
- COB:0000088 (drug product) `rdfs:seeAlso` CHEBI:23888 (drug)

This one seems pretty straightforward, so maybe there's a reason these were difficult to align before, so feedback or changes (e.g., different relationship) are welcome.

Note: I tried running the `make` command but got an error (see #174). I'm curious if there are tools built in to the make command that can automatically check that adding an equivalence like this doesn't cause any problems
