### PR TITLE
Eliminating ncbitaxon:root and instead bridging to true organism subclasses

### DIFF
--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -57,7 +57,8 @@ COB:0000019	cell in vitro	owl:equivalentClass	CL:0001034	cell in vitro	.	HumanCu
 COB:0000020	subcellular structure	rdfs:subClassOf	owl:Thing	owl:Thing	Chris will follow up	HumanCurated
 COB:0000021	gross anatomical part	owl:equivalentClass	CARO:0001008	gross anatomical part	.	HumanCurated
 COB:0000021	gross anatomical part	sssom:superClassOf	UBERON:0010000	multicellular anatomical structure	.	HumanCurated
-COB:0000022	organism	owl:equivalentClass	NCBITaxon:1	root	.	HumanCurated
+COB:0000022	organism	sssom:superClassOf	NCBITaxon:10239	Viruses	.	HumanCurated
+COB:0000022	organism	sssom:superClassOf	NCBITaxon:131567	cellular organisms	.	HumanCurated
 COB:0000022	organism	owl:equivalentClass	OBI:0100026	organism	.	HumanCurated
 COB:0000022	organism	owl:equivalentClass	CARO:0001010	organism or virus or viroid	.	HumanCurated
 COB:0000025	organization	owl:equivalentClass	OBI:0000245	organization	.	HumanCurated


### PR DESCRIPTION

**please read closely and read the related issue before commenting**

This PR removed the statement that COB:organism = NCBITaxon:root

Rationale: root includes non-organisms such as samples

See https://github.com/obophenotype/ncbitaxon/issues/10

This PR replaces that link with two subClassOf axioms

 * COB:organism
    * NCBITaxon:Viruses
    * NCBITaxon:cellular organisms

Note that if this were merged, then the union of NCBITaxon and COB would have a lattice at the top. However, it would be trivial to add NCBITaxon:1 to an anti-slim and filter it out, resulting in a tree with COB:organism as the single MRCA of all organism classes

Merging this PR has some advantages such as obviating the need to rename NCBITaxon:1, since we instead simply inject our own true parent. It leaves the structure of labeling of NCBITaxon intact

**Important** please refrain from discussing the definition of organism here, specifically whether it includes viruses. For COB purposes, this is a closed issue. See: #6