### PR TITLE
Add BFO ID mapping for "realizes"

### DIFF
--- a/src/ontology/components/cob-to-external.owl
+++ b/src/ontology/components/cob-to-external.owl
@@ -1,44 +1,18 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/cob/components/cob-to-external.owl#"
      xml:base="http://purl.obolibrary.org/obo/cob/components/cob-to-external.owl"
-     xmlns:CL="http://purl.obolibrary.org/obo/CL_"
-     xmlns:GO="http://purl.obolibrary.org/obo/GO_"
-     xmlns:PO="http://purl.obolibrary.org/obo/PO_"
-     xmlns:PR="http://purl.obolibrary.org/obo/PR_"
-     xmlns:RO="http://purl.obolibrary.org/obo/RO_"
-     xmlns:SO="http://purl.obolibrary.org/obo/SO_"
-     xmlns:BFO="http://purl.obolibrary.org/obo/BFO_"
-     xmlns:COB="http://purl.obolibrary.org/obo/COB_"
-     xmlns:GEO="http://purl.obolibrary.org/obo/GEO_"
-     xmlns:IAO="http://purl.obolibrary.org/obo/IAO_"
-     xmlns:MOP="http://purl.obolibrary.org/obo/MOP_"
-     xmlns:OBI="http://purl.obolibrary.org/obo/OBI_"
-     xmlns:PCO="http://purl.obolibrary.org/obo/PCO_"
-     xmlns:XAO="http://purl.obolibrary.org/obo/XAO_"
-     xmlns:ZFA="http://purl.obolibrary.org/obo/ZFA_"
-     xmlns:dc1="http://purl.org/dc/terms/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:CARO="http://purl.obolibrary.org/obo/CARO_"
-     xmlns:DRON="http://purl.obolibrary.org/obo/DRON_"
-     xmlns:ENVO="http://purl.obolibrary.org/obo/ENVO_"
-     xmlns:OGMS="http://purl.obolibrary.org/obo/OGMS_"
-     xmlns:PATO="http://purl.obolibrary.org/obo/PATO_"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:CHEBI="http://purl.obolibrary.org/obo/CHEBI_"
-     xmlns:SEPIO="http://purl.obolibrary.org/obo/SEPIO_"
-     xmlns:STATO="http://purl.obolibrary.org/obo/STATO_"
      xmlns:sssom="https://w3id.org/sssom/"
-     xmlns:UBERON="http://purl.obolibrary.org/obo/UBERON_"
-     xmlns:semapv="https://w3id.org/semapv/vocab/"
-     xmlns:NCBITaxon="http://purl.obolibrary.org/obo/NCBITaxon_">
+     xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob/components/cob-to-external.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/releases/2023-11-16/components/cob-to-external.owl"/>
-        <dc1:license rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://creativecommons.org/publicdomain/zero/1.0/</dc1:license>
-        <owl:versionInfo>2023-11-16</owl:versionInfo>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/releases/2024-03-20/components/cob-to-external.owl"/>
+        <terms:license rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://creativecommons.org/publicdomain/zero/1.0/</terms:license>
+        <owl:versionInfo>2024-03-20</owl:versionInfo>
         <sssom:mapping_set_id rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv</sssom:mapping_set_id>
     </owl:Ontology>
     
@@ -88,6 +62,12 @@
     <!-- https://w3id.org/sssom/subject_label -->
 
     <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/subject_label"/>
+    
+
+
+    <!-- https://w3id.org/sssom/superClassOf -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/superClassOf"/>
     
 
 
@@ -146,6 +126,22 @@
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>realized in</sssom:object_label>
         <sssom:subject_label>realized in</sssom:subject_label>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000055 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000055">
+        <owl:equivalentProperty rdf:resource="http://purl.obolibrary.org/obo/COB_0000087"/>
+    </owl:ObjectProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000055"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentProperty"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000087"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>realizes</sssom:object_label>
+        <sssom:subject_label>realizes</sssom:subject_label>
     </owl:Axiom>
     
 
@@ -385,6 +381,12 @@
         <sssom:object_label>executes</sssom:object_label>
         <sssom:subject_label>executes</sssom:subject_label>
     </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000087 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/COB_0000087"/>
     
 
 
@@ -866,22 +868,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_50906 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50906">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>characteristic</sssom:object_label>
-        <sssom:subject_label>role</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
@@ -980,7 +966,35 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000006 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_feature</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_variant</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_collection</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1032,13 +1046,51 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000017 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>plant cell</sssom:object_label>
+        <sssom:subject_label>cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/COB_0000018 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>native plant cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>xenopus cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>zebrafish cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1066,7 +1118,17 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000021 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>multicellular anatomical structure</sssom:object_label>
+        <sssom:subject_label>gross anatomical part</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1074,6 +1136,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000022">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
@@ -1081,6 +1145,22 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>organism</sssom:object_label>
+        <sssom:subject_label>organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>Viruses</sssom:object_label>
+        <sssom:subject_label>organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>organism</sssom:subject_label>
     </owl:Axiom>
     
@@ -1234,12 +1314,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/COB_0000056 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000056"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/COB_0000057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000057"/>
@@ -1378,6 +1452,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000068">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
@@ -1385,6 +1460,14 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>astronomical body part</sssom:object_label>
+        <sssom:subject_label>geophysical entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>geographical entity</sssom:object_label>
         <sssom:subject_label>geophysical entity</sssom:subject_label>
     </owl:Axiom>
     
@@ -1677,6 +1760,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
@@ -1686,6 +1771,22 @@
         <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>cellular organism</sssom:subject_label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>whole plant</sssom:object_label>
+        <sssom:subject_label>cellular organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>multicellular organism</sssom:object_label>
+        <sssom:subject_label>cellular organism</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1693,6 +1794,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000123">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
@@ -1702,6 +1804,14 @@
         <sssom:object_label>agent role</sssom:object_label>
         <sssom:subject_label>agent role</sssom:subject_label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>investigation agent role</sssom:object_label>
+        <sssom:subject_label>agent role</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1709,6 +1819,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
@@ -1716,6 +1828,22 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>quality</sssom:object_label>
+        <sssom:subject_label>characteristic</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>role</sssom:object_label>
+        <sssom:subject_label>characteristic</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_attribute</sssom:object_label>
         <sssom:subject_label>characteristic</sssom:subject_label>
     </owl:Axiom>
     
@@ -1742,22 +1870,6 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_02500000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_02500000"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>geophysical entity</sssom:object_label>
-        <sssom:subject_label>geographical entity</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -1827,35 +1939,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_10239 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>organism</sssom:object_label>
-        <sssom:subject_label>Viruses</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_131567 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>organism</sssom:object_label>
-        <sssom:subject_label>cellular organisms</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
     
 
 
@@ -1886,22 +1972,6 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000094"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000202 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000202">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>agent role</sssom:object_label>
-        <sssom:subject_label>investigation agent role</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -1977,70 +2047,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/PO_0000003 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cellular organism</sssom:object_label>
-        <sssom:subject_label>whole plant</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0009002 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0009002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cell</sssom:object_label>
-        <sssom:subject_label>plant cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0025117 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025117">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>plant anatomical space</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0025606 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025606">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>native plant cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/PR_000000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001"/>
@@ -2050,150 +2056,6 @@
     <!-- http://purl.obolibrary.org/obo/SEPIO_0000048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0000110 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000110">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_feature</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0000400 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000400">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>characteristic</sssom:object_label>
-        <sssom:subject_label>sequence_attribute</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0001060 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001060">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_variant</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0001260 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001260">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_collection</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0000466 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0000468 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cellular organism</sssom:object_label>
-        <sssom:subject_label>multicellular organism</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>gross anatomical part</sssom:object_label>
-        <sssom:subject_label>multicellular anatomical structure</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/XAO_0003012 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/XAO_0003012">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>xenopus cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/ZFA_0009000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ZFA_0009000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>zebrafish cell</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -2236,9 +2098,29 @@
         <sssom:object_label>molecule</sssom:object_label>
         <sssom:subject_label>molecular entity</sssom:subject_label>
     </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000056">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>plant anatomical space</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
+    </owl:Axiom>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.26) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.25) https://github.com/owlcs/owlapi -->
 

--- a/src/ontology/components/cob-to-external.tsv
+++ b/src/ontology/components/cob-to-external.tsv
@@ -132,6 +132,7 @@ COB:0000027	is specified input of	owl:equivalentProperty	OBI:0000295	is_specifie
 COB:0000028	is specified output of	owl:equivalentProperty	OBI:0000312	is_specified_output_of	.	semapv:ManualMappingCuration
 COB:0000039	has specified input	owl:equivalentProperty	OBI:0000293	has_specified_input	.	semapv:ManualMappingCuration
 COB:0000040	has specified output	owl:equivalentProperty	OBI:0000299	has_specified_output	.	semapv:ManualMappingCuration
+COB:0000087	realizes	owl:equivalentProperty	BFO:0000055	realizes	.	semapv:ManualMappingCuration
 COB:0000029	realized in	owl:equivalentProperty	BFO:0000054	realized in	.	semapv:ManualMappingCuration
 COB:0000513	is about	owl:equivalentProperty	IAO:0000136	is about	There is no inverse for 'is about' in IAO.	semapv:ManualMappingCuration
 COB:0000123	agent role	owl:equivalentClass	SEPIO:0000048	agent role		semapv:ManualMappingCuration


### PR DESCRIPTION
Adds a line in cob-to-external.tsv to map "realizes" to its BFO ID, as is already done with "realized by." I didn't include any files on this PR other than cob-to-external.tsv and .owl, but if an updated version of cob.owl or any other files are needed, just let me know and I'll add those.

Closes #252. 