### PR TITLE
Update cob-to-external.owl

### DIFF
--- a/src/ontology/components/cob-to-external.owl
+++ b/src/ontology/components/cob-to-external.owl
@@ -875,7 +875,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>characteristic</sssom:object_label>
         <sssom:subject_label>role</sssom:subject_label>
     </owl:Axiom>
@@ -1754,7 +1754,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>geophysical entity</sssom:object_label>
         <sssom:subject_label>geographical entity</sssom:subject_label>
     </owl:Axiom>
@@ -1836,7 +1836,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>organism</sssom:object_label>
         <sssom:subject_label>Viruses</sssom:subject_label>
     </owl:Axiom>
@@ -1852,7 +1852,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>organism</sssom:object_label>
         <sssom:subject_label>cellular organisms</sssom:subject_label>
     </owl:Axiom>
@@ -1898,7 +1898,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>agent role</sssom:object_label>
         <sssom:subject_label>investigation agent role</sssom:subject_label>
     </owl:Axiom>
@@ -1986,7 +1986,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>cellular organism</sssom:object_label>
         <sssom:subject_label>whole plant</sssom:subject_label>
     </owl:Axiom>
@@ -2002,7 +2002,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>cell</sssom:object_label>
         <sssom:subject_label>plant cell</sssom:subject_label>
     </owl:Axiom>
@@ -2018,7 +2018,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>immaterial anatomical entity</sssom:object_label>
         <sssom:subject_label>plant anatomical space</sssom:subject_label>
     </owl:Axiom>
@@ -2034,7 +2034,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>native cell</sssom:object_label>
         <sssom:subject_label>native plant cell</sssom:subject_label>
     </owl:Axiom>
@@ -2062,7 +2062,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>material entity</sssom:object_label>
         <sssom:subject_label>sequence_feature</sssom:subject_label>
     </owl:Axiom>
@@ -2078,7 +2078,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>characteristic</sssom:object_label>
         <sssom:subject_label>sequence_attribute</sssom:subject_label>
     </owl:Axiom>
@@ -2094,7 +2094,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>material entity</sssom:object_label>
         <sssom:subject_label>sequence_variant</sssom:subject_label>
     </owl:Axiom>
@@ -2110,7 +2110,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>material entity</sssom:object_label>
         <sssom:subject_label>sequence_collection</sssom:subject_label>
     </owl:Axiom>
@@ -2126,7 +2126,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>immaterial anatomical entity</sssom:object_label>
         <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
     </owl:Axiom>
@@ -2142,7 +2142,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>cellular organism</sssom:object_label>
         <sssom:subject_label>multicellular organism</sssom:subject_label>
     </owl:Axiom>
@@ -2158,7 +2158,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>gross anatomical part</sssom:object_label>
         <sssom:subject_label>multicellular anatomical structure</sssom:subject_label>
     </owl:Axiom>
@@ -2174,7 +2174,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>native cell</sssom:object_label>
         <sssom:subject_label>xenopus cell</sssom:subject_label>
     </owl:Axiom>
@@ -2190,7 +2190,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>native cell</sssom:object_label>
         <sssom:subject_label>zebrafish cell</sssom:subject_label>
     </owl:Axiom>

--- a/src/ontology/components/cob-to-external.owl
+++ b/src/ontology/components/cob-to-external.owl
@@ -872,6 +872,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/CHEBI_50906 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50906">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
@@ -1314,6 +1322,31 @@
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>collection of organisms</sssom:object_label>
         <sssom:subject_label>collection of organisms</sssom:subject_label>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000056 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000056">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>plant anatomical space</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
     </owl:Axiom>
     
 
@@ -1802,18 +1835,18 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>agent role</sssom:object_label>
-        <sssom:subject_label>agent role</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
         <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>investigation agent role</sssom:object_label>
+        <sssom:subject_label>agent role</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>agent role</sssom:object_label>
         <sssom:subject_label>agent role</sssom:subject_label>
     </owl:Axiom>
     
@@ -1828,6 +1861,14 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>quality</sssom:object_label>
+        <sssom:subject_label>characteristic</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
         <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
@@ -1840,14 +1881,6 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>sequence_attribute</sssom:object_label>
-        <sssom:subject_label>characteristic</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>quality</sssom:object_label>
         <sssom:subject_label>characteristic</sssom:subject_label>
     </owl:Axiom>
     
@@ -1874,6 +1907,14 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_02500000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_02500000"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
+    </owl:Class>
     
 
 
@@ -1943,9 +1984,19 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_10239 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_131567 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+    </owl:Class>
     
 
 
@@ -1976,6 +2027,14 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000094"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000202 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000202">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
+    </owl:Class>
     
 
 
@@ -2051,6 +2110,38 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0000003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0009002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0009002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0025117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PO_0025606 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025606">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PR_000000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001"/>
@@ -2060,6 +2151,78 @@
     <!-- http://purl.obolibrary.org/obo/SEPIO_0000048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000110 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000110">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000400 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000400">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001060 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001060">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001260 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000466 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000468 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/XAO_0003012 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/XAO_0003012">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ZFA_0009000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ZFA_0009000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+    </owl:Class>
     
 
 
@@ -2101,26 +2264,6 @@
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>molecule</sssom:object_label>
         <sssom:subject_label>molecular entity</sssom:subject_label>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000056">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>plant anatomical space</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
     </owl:Axiom>
 </rdf:RDF>
 

--- a/src/ontology/components/cob-to-external.owl
+++ b/src/ontology/components/cob-to-external.owl
@@ -91,12 +91,6 @@
     
 
 
-    <!-- https://w3id.org/sssom/superClassOf -->
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/superClassOf"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -877,6 +871,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50906">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>characteristic</sssom:object_label>
+        <sssom:subject_label>role</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -978,35 +980,7 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000006 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>sequence_feature</sssom:object_label>
-        <sssom:subject_label>material entity</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>sequence_variant</sssom:object_label>
-        <sssom:subject_label>material entity</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>sequence_collection</sssom:object_label>
-        <sssom:subject_label>material entity</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006"/>
     
 
 
@@ -1058,51 +1032,13 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000017 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>plant cell</sssom:object_label>
-        <sssom:subject_label>cell</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017"/>
     
 
 
     <!-- http://purl.obolibrary.org/obo/COB_0000018 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native plant cell</sssom:object_label>
-        <sssom:subject_label>native cell</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>xenopus cell</sssom:object_label>
-        <sssom:subject_label>native cell</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>zebrafish cell</sssom:object_label>
-        <sssom:subject_label>native cell</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018"/>
     
 
 
@@ -1130,17 +1066,7 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000021 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>multicellular anatomical structure</sssom:object_label>
-        <sssom:subject_label>gross anatomical part</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021"/>
     
 
 
@@ -1148,8 +1074,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000022">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
@@ -1157,22 +1081,6 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>organism</sssom:object_label>
-        <sssom:subject_label>organism</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>Viruses</sssom:object_label>
-        <sssom:subject_label>organism</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>organism</sssom:subject_label>
     </owl:Axiom>
     
@@ -1328,26 +1236,7 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000056 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000056">
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>plant anatomical space</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000056"/>
     
 
 
@@ -1489,7 +1378,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000068">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
@@ -1497,14 +1385,6 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>astronomical body part</sssom:object_label>
-        <sssom:subject_label>geophysical entity</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>geographical entity</sssom:object_label>
         <sssom:subject_label>geophysical entity</sssom:subject_label>
     </owl:Axiom>
     
@@ -1797,8 +1677,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
@@ -1808,22 +1686,6 @@
         <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>cellular organism</sssom:subject_label>
     </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>whole plant</sssom:object_label>
-        <sssom:subject_label>cellular organism</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>multicellular organism</sssom:object_label>
-        <sssom:subject_label>cellular organism</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -1831,16 +1693,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000123">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>investigation agent role</sssom:object_label>
-        <sssom:subject_label>agent role</sssom:subject_label>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
@@ -1856,8 +1709,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
-        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
@@ -1865,22 +1716,6 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>quality</sssom:object_label>
-        <sssom:subject_label>characteristic</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>role</sssom:object_label>
-        <sssom:subject_label>characteristic</sssom:subject_label>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>sequence_attribute</sssom:object_label>
         <sssom:subject_label>characteristic</sssom:subject_label>
     </owl:Axiom>
     
@@ -1915,6 +1750,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>geophysical entity</sssom:object_label>
+        <sssom:subject_label>geographical entity</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1989,6 +1832,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>organism</sssom:object_label>
+        <sssom:subject_label>Viruses</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1997,6 +1848,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>organism</sssom:object_label>
+        <sssom:subject_label>cellular organisms</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2035,6 +1894,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000202">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>agent role</sssom:object_label>
+        <sssom:subject_label>investigation agent role</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2115,6 +1982,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0000003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>cellular organism</sssom:object_label>
+        <sssom:subject_label>whole plant</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2123,6 +1998,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0009002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>cell</sssom:object_label>
+        <sssom:subject_label>plant cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2131,6 +2014,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
+        <sssom:subject_label>plant anatomical space</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2139,6 +2030,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025606">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>native cell</sssom:object_label>
+        <sssom:subject_label>native plant cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2159,6 +2058,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>material entity</sssom:object_label>
+        <sssom:subject_label>sequence_feature</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2167,6 +2074,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>characteristic</sssom:object_label>
+        <sssom:subject_label>sequence_attribute</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2175,6 +2090,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>material entity</sssom:object_label>
+        <sssom:subject_label>sequence_variant</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2183,6 +2106,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001260">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>material entity</sssom:object_label>
+        <sssom:subject_label>sequence_collection</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2191,6 +2122,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2199,6 +2138,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>cellular organism</sssom:object_label>
+        <sssom:subject_label>multicellular organism</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2207,6 +2154,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>gross anatomical part</sssom:object_label>
+        <sssom:subject_label>multicellular anatomical structure</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2215,6 +2170,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/XAO_0003012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>native cell</sssom:object_label>
+        <sssom:subject_label>xenopus cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -2223,6 +2186,14 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ZFA_0009000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/MappingInversion"/>
+        <sssom:object_label>native cell</sssom:object_label>
+        <sssom:subject_label>zebrafish cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 

--- a/src/ontology/components/cob-to-external.owl
+++ b/src/ontology/components/cob-to-external.owl
@@ -36,9 +36,9 @@
      xmlns:semapv="https://w3id.org/semapv/vocab/"
      xmlns:NCBITaxon="http://purl.obolibrary.org/obo/NCBITaxon_">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cob/components/cob-to-external.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/releases/2023-11-16/components/cob-to-external.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cob/releases/2024-03-22/components/cob-to-external.owl"/>
         <dc1:license rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://creativecommons.org/publicdomain/zero/1.0/</dc1:license>
-        <owl:versionInfo>2023-11-16</owl:versionInfo>
+        <owl:versionInfo>2024-03-22</owl:versionInfo>
         <sssom:mapping_set_id rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/cob/components/cob-to-external.tsv</sssom:mapping_set_id>
     </owl:Ontology>
     
@@ -88,6 +88,12 @@
     <!-- https://w3id.org/sssom/subject_label -->
 
     <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/subject_label"/>
+    
+
+
+    <!-- https://w3id.org/sssom/superClassOf -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/superClassOf"/>
     
 
 
@@ -866,22 +872,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_50906 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50906">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>characteristic</sssom:object_label>
-        <sssom:subject_label>role</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
@@ -980,7 +970,35 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000006 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000006">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_feature</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_variant</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_collection</sssom:object_label>
+        <sssom:subject_label>material entity</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1032,13 +1050,51 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000017 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000017">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>plant cell</sssom:object_label>
+        <sssom:subject_label>cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/COB_0000018 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000018">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>native plant cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>xenopus cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>zebrafish cell</sssom:object_label>
+        <sssom:subject_label>native cell</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1066,7 +1122,17 @@
 
     <!-- http://purl.obolibrary.org/obo/COB_0000021 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000021">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>multicellular anatomical structure</sssom:object_label>
+        <sssom:subject_label>gross anatomical part</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1074,6 +1140,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000022">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
@@ -1081,6 +1149,22 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>organism</sssom:object_label>
+        <sssom:subject_label>organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>Viruses</sssom:object_label>
+        <sssom:subject_label>organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>organism</sssom:subject_label>
     </owl:Axiom>
     
@@ -1234,12 +1318,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/COB_0000056 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000056"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/COB_0000057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000057"/>
@@ -1378,6 +1456,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000068">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
@@ -1385,6 +1464,14 @@
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>astronomical body part</sssom:object_label>
+        <sssom:subject_label>geophysical entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>geographical entity</sssom:object_label>
         <sssom:subject_label>geophysical entity</sssom:subject_label>
     </owl:Axiom>
     
@@ -1677,6 +1764,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000118">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
@@ -1686,6 +1775,22 @@
         <sssom:object_label>cellular organisms</sssom:object_label>
         <sssom:subject_label>cellular organism</sssom:subject_label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>whole plant</sssom:object_label>
+        <sssom:subject_label>cellular organism</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>multicellular organism</sssom:object_label>
+        <sssom:subject_label>cellular organism</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1693,6 +1798,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000123">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
@@ -1702,6 +1808,14 @@
         <sssom:object_label>agent role</sssom:object_label>
         <sssom:subject_label>agent role</sssom:subject_label>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>investigation agent role</sssom:object_label>
+        <sssom:subject_label>agent role</sssom:subject_label>
+    </owl:Axiom>
     
 
 
@@ -1709,7 +1823,25 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000502">
         <owl:equivalentClass rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>role</sssom:object_label>
+        <sssom:subject_label>characteristic</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>sequence_attribute</sssom:object_label>
+        <sssom:subject_label>characteristic</sssom:subject_label>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
@@ -1742,22 +1874,6 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_02500000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_02500000"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000068"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>geophysical entity</sssom:object_label>
-        <sssom:subject_label>geographical entity</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -1827,35 +1943,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_10239 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>organism</sssom:object_label>
-        <sssom:subject_label>Viruses</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_131567 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>organism</sssom:object_label>
-        <sssom:subject_label>cellular organisms</sssom:subject_label>
-    </owl:Axiom>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
     
 
 
@@ -1886,22 +1976,6 @@
     <!-- http://purl.obolibrary.org/obo/OBI_0000094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000094"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000202 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000202">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0000202"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000123"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>agent role</sssom:object_label>
-        <sssom:subject_label>investigation agent role</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -1977,70 +2051,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/PO_0000003 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cellular organism</sssom:object_label>
-        <sssom:subject_label>whole plant</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0009002 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0009002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0009002"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000017"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cell</sssom:object_label>
-        <sssom:subject_label>plant cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0025117 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025117">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>plant anatomical space</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/PO_0025606 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PO_0025606">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PO_0025606"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>native plant cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/PR_000000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001"/>
@@ -2050,150 +2060,6 @@
     <!-- http://purl.obolibrary.org/obo/SEPIO_0000048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SEPIO_0000048"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0000110 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000110">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000110"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_feature</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0000400 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000400">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000502"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>characteristic</sssom:object_label>
-        <sssom:subject_label>sequence_attribute</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0001060 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001060">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001060"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_variant</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/SO_0001260 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001260">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001260"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000006"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>material entity</sssom:object_label>
-        <sssom:subject_label>sequence_collection</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0000466 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
-        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0000468 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000118"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>cellular organism</sssom:object_label>
-        <sssom:subject_label>multicellular organism</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000021"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>gross anatomical part</sssom:object_label>
-        <sssom:subject_label>multicellular anatomical structure</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/XAO_0003012 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/XAO_0003012">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/XAO_0003012"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>xenopus cell</sssom:subject_label>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/ZFA_0009000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ZFA_0009000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/ZFA_0009000"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/COB_0000018"/>
-        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
-        <sssom:object_label>native cell</sssom:object_label>
-        <sssom:subject_label>zebrafish cell</sssom:subject_label>
-    </owl:Axiom>
     
 
 
@@ -2235,6 +2101,26 @@
         <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
         <sssom:object_label>molecule</sssom:object_label>
         <sssom:subject_label>molecular entity</sssom:subject_label>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000056">
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:superClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/PO_0025117"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>plant anatomical space</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/COB_0000056"/>
+        <owl:annotatedProperty rdf:resource="https://w3id.org/sssom/superClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:object_label>immaterial anatomical entity</sssom:object_label>
+        <sssom:subject_label>immaterial anatomical entity</sssom:subject_label>
     </owl:Axiom>
 </rdf:RDF>
 


### PR DESCRIPTION
Update with ROBOT version 1.9.5 and SSSOM version 0.4.4 without changing cob-to-external.tsv.